### PR TITLE
Fix implementation of `para`

### DIFF
--- a/Data/Functor/Foldable.hs
+++ b/Data/Functor/Foldable.hs
@@ -106,7 +106,7 @@ class Functor (Base t) => Foldable t where
   cata f = c where c = f . fmap c . project
 
   para :: (Base t (t, a) -> a) -> t -> a
-  para t = p where p x = t . fmap (((,) x) . p) $ project x
+  para t = p where p x = t . fmap ((,) <*> p) $ project x
 
   gpara :: (Unfoldable t, Comonad w) => (forall b. Base t (w b) -> w (Base t b)) -> (Base t (EnvT t w a) -> a) -> t -> a
   gpara t = gzygo embed t


### PR DESCRIPTION
Commit e347108444895bd86c5ee07f2ab0a424593dc821 broke `para`:

```
import Data.Functor.Foldable
import Data.Maybe

phi :: Maybe (Fix Maybe, Bool) -> Bool
phi Nothing = False
phi (Just (a,_)) = isJust $ project a

{-

λ> zygo embed phi (Fix $ Just $ Fix Nothing)
False
λ> para phi (Fix $ Just $ Fix Nothing)
True

-}
```

I think this is the correct implementation.
