### PR TITLE
Added chronomorphisms because Free is available now

### DIFF
--- a/Data/Functor/Foldable.hs
+++ b/Data/Functor/Foldable.hs
@@ -430,7 +430,6 @@ distHisto = distGHisto id
 distGHisto :: (Functor f, Functor h) => (forall b. f (h b) -> h (f b)) -> f (Cofree h a) -> Cofree h (f a)
 distGHisto k = Cofree.unfold (\as -> (extract <$> as, k (Cofree.unwrap <$> as)))
 
--- TODO: futu & chrono, these require Free monads
 -- TODO: distGApoT, requires EitherT
 
 chrono :: Functor f => (f (Cofree f b) -> b) -> (a -> f (Free f a)) -> (a -> b)

--- a/Data/Functor/Foldable.hs
+++ b/Data/Functor/Foldable.hs
@@ -34,6 +34,8 @@ module Data.Functor.Foldable
   , histo
   , ghisto
   , futu
+  , chrono
+  , gchrono
   -- ** Distributive laws
   , distCata
   , distPara
@@ -430,6 +432,16 @@ distGHisto k = Cofree.unfold (\as -> (extract <$> as, k (Cofree.unwrap <$> as)))
 
 -- TODO: futu & chrono, these require Free monads
 -- TODO: distGApoT, requires EitherT
+
+chrono :: Functor f => (f (Cofree f b) -> b) -> (a -> f (Free f a)) -> (a -> b)
+chrono = ghylo distHisto distFutu
+
+gchrono :: (Functor f, Functor w, Functor m) =>
+           (forall b. f (w b) -> w (f b)) ->
+           (forall b. m (f b) -> f (m b)) ->
+           (f (Cofree w b) -> b) -> (a -> f (Free m a)) ->
+           (a -> b)
+gchrono w m = ghylo (distGHisto w) (distGFutu m)
 
 -- | Mendler-style iteration
 mcata :: (forall y. (y -> c) -> f y -> c) -> Fix f -> c


### PR DESCRIPTION
Actually, I'm just guessing as to that being the reason they were missing. I stumbled across https://github.com/ekmett/ekmett.github.com/blob/master/haskell/Chronomorphism.hs and wondered why it wasn't on Hackage.