### PR TITLE
Fix `unfold` name conflict with `free-4.12`

### DIFF
--- a/Data/Functor/Foldable.hs
+++ b/Data/Functor/Foldable.hs
@@ -78,7 +78,7 @@ import Control.Comonad.Trans.Env
 import qualified Control.Comonad.Cofree as Cofree
 import Control.Comonad.Cofree (Cofree(..))
 import Control.Monad (liftM, join)
-import Control.Monad.Free
+import Control.Monad.Free hiding (unfold)
 import Data.Functor.Identity
 import Control.Arrow
 import Data.Function (on)


### PR DESCRIPTION
Your new version of [`free`](http://hackage.haskell.org/package/free-4.12.1) uploaded May 15th includes a function `unfold` which conflicts with the one in this package.

```
[1 of 1] Compiling Data.Functor.Foldable ( Data/Functor/Foldable.hs, dist/build/Data/Functor/Foldable.o )
Data/Functor/Foldable.hs:62:5:
    Ambiguous occurrence ‘unfold’
    It could refer to either ‘Data.Functor.Foldable.unfold’,
                             defined at Data/Functor/Foldable.hs:179:1
                          or ‘Control.Monad.Free.unfold’,
                             imported from ‘Control.Monad.Free’ at Data/Functor/Foldable.hs:81:1-25
```