### PR TITLE
Qualify module export of unfold

### DIFF
--- a/Data/Functor/Foldable.hs
+++ b/Data/Functor/Foldable.hs
@@ -59,7 +59,7 @@ module Data.Functor.Foldable
   , refix
   -- * Common names
   , fold, gfold
-  , unfold, gunfold
+  , Data.Functor.Foldable.unfold, gunfold
   , refold, grefold
   -- * Mendler-style
   , mcata


### PR DESCRIPTION
Without this, 4.1.1 doesn't build against the latest version of free.