### PR TITLE
Bifunctors

### DIFF
--- a/Data/Functor/Foldable.hs
+++ b/Data/Functor/Foldable.hs
@@ -25,8 +25,6 @@
 #endif
 #endif
 
-
-
 -----------------------------------------------------------------------------
 -- |
 -- Copyright   :  (C) 2008-2015 Edward Kmett
@@ -281,9 +279,6 @@ instance Show a => Show1 (ListF a) where showsPrec1 = showsPrec
 instance Read a => Read1 (ListF a) where readsPrec1 = readsPrec
 #endif
 
--- TODO: add instances for Eq1/2, Ord1/2, Show1/2, Read1/2
--- Typeable, Typeable1, Generic
-
 -- These instances cannot be auto-derived on with GHC <= 7.6
 instance Functor (ListF a) where
   fmap _ Nil        = Nil
@@ -483,9 +478,23 @@ instance Bi.Bifoldable f => F.Foldable (Bifix f) where
 instance Bi.Bitraversable f => T.Traversable (Bifix f) where
   traverse f = go where go (Bifix x) = Bifix <$> Bi.bitraverse go f x
 
+#if EXPLICIT_DICT_FUNCTOR_CLASSES
+-- | Cannot write this instances, as transformes-0.4 doesn't have *2 classes.
+instance (Eq2 f, Eq a) => Eq (Bifix f a) where
+  (==) = eq1
+instance (Ord2 f, Ord a) => Ord (Bifix f a) where
+  compare = compare1
+
+instance Eq2 f => Eq1 (Bifix f) where
+  liftEq eq = go where go (Bifix a) (Bifix b) = liftEq2 go eq a b
+instance Ord2 f => Ord1 (Bifix f) where
+  liftCompare cmp = go where
+    go (Bifix a) (Bifix b) = liftCompare2 go cmp a b
+#endif
+
 -- TODO: add instances for
---   Eq, Ord, Show, Read,
---   Eq1, Ord1, Show1, Read1
+--   Show, Read,
+--   Show1, Read1
 --   Typeable, Data
 
 type instance Base (Bifix f a) = Flip f a

--- a/Data/Functor/Foldable.hs
+++ b/Data/Functor/Foldable.hs
@@ -495,13 +495,29 @@ instance Ord2 f => Ord1 (Bifix f) where
 -- TODO: add instances for
 --   Show, Read,
 --   Show1, Read1
---   Typeable, Data
 
 type instance Base (Bifix f a) = Flip f a
 instance Bi.Bifunctor f => Recursive (Bifix f a) where
   project = Flip . unbifix
 instance Bi.Bifunctor f => Corecursive (Bifix f a) where
   embed = Bifix . runFlip
+
+#if __GLASGOW_HASKELL__
+#if HAS_POLY_TYPEABLE
+deriving instance Typeable Bifix
+deriving instance
+  ( Typeable (f :: * -> k -> *)
+  , Typeable a
+  , Typeable (Bifix :: (* -> k -> *) -> k -> *)
+  , Data (f (Bifix f a) a))
+  => Data (Bifix f a)
+#else
+-- TODO: Implement later
+#endif
+#endif
+
+-- todo add toBifix, fromBifix
+--
 
 -------------------------------------------------------------------------------
 -- Lambek

--- a/Data/Functor/Foldable.hs
+++ b/Data/Functor/Foldable.hs
@@ -80,6 +80,9 @@ module Data.Functor.Foldable
   , ghylo
   -- ** Changing representation
   , refix
+  , refixWith
+  , toBifix
+  , fromBifix
   -- * Common names
   , fold, gfold
   , unfold, gunfold
@@ -533,8 +536,18 @@ deriving instance
 #endif
 #endif
 
--- todo add toBifix, fromBifix
+-- |
 --
+-- > refixWith (Flip . Flip) "foo" :: Bifix (Flip ListF) Char
+-- No instance for (Show2 (Flip ListF))
+refixWith :: (Recursive s, Corecursive t) => (Base s t -> Base t t) -> s -> t
+refixWith f = cata (embed . f)
+
+toBifix :: (Recursive s, Base s ~ f a, Bi.Bifunctor f) => s -> Bifix (Flip f) a
+toBifix = refixWith (Flip . Flip)
+
+fromBifix :: (Corecursive t, Base t ~ f a, Bi.Bifunctor f) => Bifix (Flip f) a -> t
+fromBifix = refixWith (runFlip . runFlip)
 
 -------------------------------------------------------------------------------
 -- Lambek


### PR DESCRIPTION
I'm not sure about this changes, so need comments.

It seems that `Prim [a]` is used only to define `ListF`. Yet by using "top-level" type we could write more useful instances for it, i.e. `Bifunctor` etc. This is what first commit does. I'm very :+1: for this change.

Second commit is more controversial, and I'm not sure about it ATM, just came to mind. It adds a new `newtype Bifix f a`, which is very similar to `Fix`, but `f` is now `Bifunctor`, which allows to write `Functor (Bifix f)` instance. Is this is *practically* useful to anyone? I don't know! Yet this highlights the limitations of Haskell atm, as `Const (Maybe a)` isn't a `Bifunctor` as we would like it to be to use with `Bifix`, we would need `newtype Const1 f a b = Const (f a)` for this to work.

I wrote only handful instances (and added TODOs), but I'll add the rest if the commits (only first or second) are ok.