### PR TITLE
template-haskell derivation

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,6 @@
+## 5.0.1
+* Add `Data.Functor.Foldable.TH` module, which provides derivation of base functors via Template Haskell.
+
 ## 5
 * Renamed `Foldable` to `Recursive` and `Unfoldable` to `Corecursive`. With `Foldable` in `Prelude` in GHC 7.10+, having a needlessly conflicting name seemed silly.
 * Add support for GHC-8.0.1

--- a/Data/Functor/Foldable/TH.hs
+++ b/Data/Functor/Foldable/TH.hs
@@ -139,7 +139,7 @@ makePrimForDec' rules tyName vars cons = do
     let projDec = FunD projectValName (mkMorphism id toFName args)
     let recursiveDec = InstanceD Nothing [] (ConT recursiveTypeName `AppT` s) [projDec]
 
-    -- instance Corecurive
+    -- instance Corecursive
     let embedDec = FunD embedValName (mkMorphism toFName id args)
     let corecursiveDec = InstanceD Nothing [] (ConT corecursiveTypeName `AppT` s) [embedDec]
 
@@ -153,7 +153,7 @@ mkMorphism
     -> [(Name, [Name])]
     -> [Clause]
 mkMorphism nFrom nTo args = flip map args $ \(n, fs) -> Clause
-    [ConP (nFrom n) (map VarP fs)]     -- patterns
+    [ConP (nFrom n) (map VarP fs)]                      -- patterns
     (NormalB $ foldl AppE (ConE $ nTo n) (map VarE fs)) -- body
     [] -- where dec
 

--- a/Data/Functor/Foldable/TH.hs
+++ b/Data/Functor/Foldable/TH.hs
@@ -60,11 +60,10 @@ import Paths_recursion_schemes (version)
 -- /Notes:/
 --
 -- 'makeBaseFunctor' works properly only with ADTs.
--- Existentials and GADTs etc. may work, if the recursion is parametric.
+-- Existentials and GADTs aren't supported,
+-- as we don't try to de better than
+-- <https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/glasgow_exts.html#deriving-functor-instances GHC's DeriveFunctor>.
 --
--- /TODO:/
---
--- make GADTs work
 makeBaseFunctor :: Name -> DecsQ
 makeBaseFunctor = makeBaseFunctorWith baseRules
 

--- a/Data/Functor/Foldable/TH.hs
+++ b/Data/Functor/Foldable/TH.hs
@@ -1,0 +1,141 @@
+{-# LANGUAGE TemplateHaskell #-}
+module Data.Functor.Foldable.TH
+  ( makeBaseFunctor
+  ) where
+
+import Data.Bifunctor (first)
+import Data.Functor.Foldable
+import Language.Haskell.TH
+
+makeBaseFunctor :: Name -> DecsQ
+makeBaseFunctor name = reify name >>= f
+  where
+    f (TyConI dec) = makePrimForDec dec
+    f _            = fail "makeBaseFunctor: Expected type constructor name"
+
+toFName :: Name -> Name
+toFName name = mkName $ nameBase name ++ "F"
+
+varBindName :: TyVarBndr -> Name
+varBindName (PlainTV n)    = n
+varBindName (KindedTV n _) = n
+
+makePrimForDec :: Dec -> DecsQ
+makePrimForDec dec = case dec of
+#if MIN_VERSION_template_haskell(2,11,0)
+  DataD    _ tyName vars _ cons _ -> do
+    makePrimForDec' tyName vars cons
+#else
+  DataD    _ tyName vars cons _ ->
+    makePrimForDec' tyName vars cons
+#endif
+  _ -> fail "makeFieldOptics: Expected data type-constructor"
+
+makePrimForDec' :: Name -> [TyVarBndr] -> [Con] -> DecsQ
+makePrimForDec' tyName vars cons = do
+    -- variable parameters
+    let vars' = map VarT (typeVars vars)
+    -- Name of base functor
+    let tyNameF = toFName tyName
+    -- Recursive type
+    let s = conAppsT tyName vars'
+    -- Additional argument
+    rName <- newName "r"
+    let r = VarT rName
+    -- Vars
+    let varsF = vars ++ [PlainTV rName]
+
+    let fieldCons = map normalizeConstructor cons
+    let fieldConsF = map (toF s r) fieldCons
+
+    -- TODO: transform 'cons' directly
+    let consF = map makeCon fieldConsF
+
+    -- Data definition
+    let dataDec = DataD [] tyNameF varsF Nothing consF [ConT ''Functor]
+
+    -- type instance Base
+    let baseDec = TySynInstD ''Base (TySynEqn [s] $ conAppsT tyNameF vars')
+
+    -- instance Recursive
+    args <- (traverse . traverse . traverse) (\_ -> newName "x") fieldCons
+
+    let projDec = FunD 'project (mkMorphism id toFName args)
+    let recursiveDec = InstanceD Nothing [] (ConT ''Recursive `AppT` s) [projDec]
+
+    -- instance Corecurive
+    let embedDec = FunD 'embed (mkMorphism toFName id args)
+    let corecursiveDec = InstanceD Nothing [] (ConT ''Corecursive `AppT` s) [embedDec]
+
+    -- Combine
+    pure [dataDec, baseDec, recursiveDec, corecursiveDec]
+  where
+    toF s r (n, fs) = (toFName n, map (toF' s r) fs)
+    toF' s r (n, t) = (fmap toFName n, substType s r t)
+
+    makeCon (name, fs) = NormalC name (map (f . snd) fs)
+      where
+        f t = (Bang NoSourceUnpackedness NoSourceStrictness, t)
+
+-- | makes clauses to rename constructors
+mkMorphism
+    :: (Name -> Name)
+    -> (Name -> Name)
+    -> [(Name, [Name])]
+    -> [Clause]
+mkMorphism nFrom nTo args = flip map args $ \(n, fs) -> Clause
+    [ConP (nFrom n) (map VarP fs)]     -- patterns
+    (NormalB $ foldl AppE (ConE $ nTo n) (map VarE fs)) -- body
+    [] -- where dec
+
+-- | Normalized the Con type into a uniform positional representation,
+-- eliminating the variance between records, infix constructors, and normal
+-- constructors.
+normalizeConstructor
+  :: Con
+  -> (Name, [(Maybe Name, Type)]) -- ^ constructor name, field name, field type
+
+normalizeConstructor (RecC n xs) =
+  (n, [ (Just fieldName, ty) | (fieldName,_,ty) <- xs])
+
+normalizeConstructor (NormalC n xs) =
+  (n, [ (Nothing, ty) | (_,ty) <- xs])
+
+normalizeConstructor (InfixC (_,ty1) n (_,ty2)) =
+  (n, [ (Nothing, ty1), (Nothing, ty2) ])
+
+normalizeConstructor (ForallC _ _ con) =
+  (fmap . fmap . first) (const Nothing) (normalizeConstructor con)
+
+#if MIN_VERSION_template_haskell(2,11,0)
+normalizeConstructor (GadtC ns xs _) =
+  (head ns, [ (Nothing, ty) | (_,ty) <- xs])
+
+normalizeConstructor (RecGadtC ns xs _) =
+  (head ns, [ (Just fieldName, ty) | (fieldName,_,ty) <- xs])
+#endif
+
+-- | Extraty type variables
+typeVars :: [TyVarBndr] -> [Name]
+typeVars = map varBindName
+
+-- | Apply arguments to a type constructor.
+conAppsT :: Name -> [Type] -> Type
+conAppsT conName = foldl AppT (ConT conName)
+
+-- | Provides substitution for types
+substType
+    :: Type
+    -> Type
+    -> Type
+    -> Type
+substType a b = go
+  where
+    go x | x == a = b
+    go (VarT n) = VarT n
+    go (AppT l r) = AppT (go l) (go r)
+#if MIN_VERSION_template_haskell(2,11,0)
+    go (ParensT t) = ParensT (go t)
+#endif
+    -- TODO:
+    go x = x

--- a/Data/Functor/Foldable/TH.hs
+++ b/Data/Functor/Foldable/TH.hs
@@ -14,6 +14,10 @@ import Language.Haskell.TH
 import Language.Haskell.TH.Syntax (mkNameG_tc, mkNameG_v)
 import Data.Char (GeneralCategory (..), generalCategory)
 import Data.Orphans ()
+#ifndef CURRENT_PACKAGE_KEY
+import Data.Version (showVersion)
+import Paths_recursion_schemes (version)
+#endif
 
 -- | Build base functor with a sensible default configuration.
 --

--- a/Data/Functor/Foldable/TH.hs
+++ b/Data/Functor/Foldable/TH.hs
@@ -86,6 +86,7 @@ data BaseRules = BaseRules
     , _baseRulesField :: Name -> Name
     }
 
+-- | Default 'BaseRules': prepend @F@ or @$@ to data type, constructors and field names.
 baseRules :: BaseRules
 baseRules = BaseRules
     { _baseRulesType  = toFName

--- a/Data/Functor/Foldable/TH.hs
+++ b/Data/Functor/Foldable/TH.hs
@@ -264,13 +264,18 @@ substType
     -> Type
 substType a b = go
   where
-    go x | x == a = b
-    go (VarT n) = VarT n
-    go (AppT l r) = AppT (go l) (go r)
+    go x | x == a         = b
+    go (VarT n)           = VarT n
+    go (AppT l r)         = AppT (go l) (go r)
+    go (InfixT l n r)     = InfixT (go l) n (go r)
+    go (UInfixT l n r)    = UInfixT (go l) n (go r)
+    go (ForallT xs ctx t) = ForallT xs ctx (go t)
+    -- This may fail with kind error
+    go (SigT t k)         = SigT (go t) k
 #if MIN_VERSION_template_haskell(2,11,0)
-    go (ParensT t) = ParensT (go t)
+    go (ParensT t)        = ParensT (go t)
 #endif
-    -- TODO:
+    -- Rest are unchanged
     go x = x
 
 -------------------------------------------------------------------------------

--- a/Data/Functor/Foldable/TH.hs
+++ b/Data/Functor/Foldable/TH.hs
@@ -29,7 +29,7 @@ import Language.Haskell.TH
 --     = LitF a
 --     | Add x x
 --     | Mul x x
---   deriving ('Functor')
+--   deriving ('Functor', 'Foldable', 'Traversable')
 --
 -- type instance 'Base' (Expr a) = ExprF a
 --
@@ -117,7 +117,7 @@ makePrimForDec' tyName vars cons = do
     let consF = map makeCon fieldConsF
 
     -- Data definition
-    let dataDec = DataD [] tyNameF varsF Nothing consF [ConT ''Functor]
+    let dataDec = DataD [] tyNameF varsF Nothing consF [ConT ''Functor, ConT ''Foldable, ConT ''Traversable]
 
     -- type instance Base
     let baseDec = TySynInstD ''Base (TySynEqn [s] $ conAppsT tyNameF vars')

--- a/Data/Functor/Foldable/TH.hs
+++ b/Data/Functor/Foldable/TH.hs
@@ -2,8 +2,11 @@
 module Data.Functor.Foldable.TH
   ( makeBaseFunctor
   , makeBaseFunctorWith
-  , BaseRules (..)
+  , BaseRules
   , baseRules
+  , baseRulesType
+  , baseRulesCon
+  , baseRulesField
   ) where
 
 import Control.Applicative as A
@@ -29,6 +32,8 @@ import Paths_recursion_schemes (version)
 --     | Add (Expr a) (Expr a)
 --     | Expr a :* [Expr a]
 --   deriving (Show)
+--
+-- 'makeBaseFunctor' ''Expr
 -- @
 --
 -- will create
@@ -61,7 +66,7 @@ import Paths_recursion_schemes (version)
 --
 -- 'makeBaseFunctor' works properly only with ADTs.
 -- Existentials and GADTs aren't supported,
--- as we don't try to de better than
+-- as we don't try to do better than
 -- <https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/glasgow_exts.html#deriving-functor-instances GHC's DeriveFunctor>.
 --
 makeBaseFunctor :: Name -> DecsQ
@@ -87,6 +92,24 @@ baseRules = BaseRules
     , _baseRulesCon   = toFName
     , _baseRulesField = toFName
     }
+
+-- | How to name the base functor type.
+--
+-- Default is to prepened @F@ or @$@.
+baseRulesType :: Functor f => ((Name -> Name) -> f (Name -> Name)) -> BaseRules -> f BaseRules
+baseRulesType f rules = (\x -> rules { _baseRulesType = x }) <$> f (_baseRulesType rules)
+
+-- | How to rename the base functor type constructors.
+--
+-- Default is to prepened @F@ or @$@.
+baseRulesCon :: Functor f => ((Name -> Name) -> f (Name -> Name)) -> BaseRules -> f BaseRules
+baseRulesCon f rules = (\x -> rules { _baseRulesCon = x }) <$> f (_baseRulesCon rules)
+
+-- | How to rename the base functor type field names (in records).
+--
+-- Default is to prepened @F@ or @$@.
+baseRulesField :: Functor f => ((Name -> Name) -> f (Name -> Name)) -> BaseRules -> f BaseRules
+baseRulesField f rules = (\x -> rules { _baseRulesField = x }) <$> f (_baseRulesField rules)
 
 toFName :: Name -> Name
 toFName = mkName . f . nameBase

--- a/examples/Expr.hs
+++ b/examples/Expr.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE TemplateHaskell, KindSignatures, DeriveTraversable, TypeFamilies #-}
+{-# LANGUAGE TemplateHaskell, KindSignatures, TypeFamilies #-}
+{-# LANGUAGE DeriveFunctor, DeriveFoldable, DeriveTraversable #-}
 module Main where
 
 import Data.Functor.Foldable

--- a/examples/Expr.hs
+++ b/examples/Expr.hs
@@ -3,36 +3,33 @@ module Main where
 
 import Data.Functor.Foldable
 import Data.Functor.Foldable.TH
-
+import Data.List (foldl')
 import Test.HUnit
 
 data Expr a
     = Lit a
     | Add (Expr a) (Expr a)
-    | Mul (Expr a) (Expr a)
+    | Expr a :* [Expr a]
   deriving (Show)
 
 makeBaseFunctor ''Expr
 
 expr1 :: Expr Int
-expr1 = Add (Lit 2) (Mul (Lit 3) (Lit 4))
+expr1 = Add (Lit 2) (Lit 3 :* [Lit 4])
 
 main :: IO ()
 main = do
     let expr2 = ana divCoalg 55 :: Expr Int
     14 @=? cata evalAlg expr1
     55 @=? cata evalAlg expr2
-
-    -- assert expr1 evaluates to 14
-    -- assert expr2 evaluates to 55, QuickCheck ?
   where
     evalAlg (LitF x)   = x
     evalAlg (AddF x y) = x + y
-    evalAlg (MulF x y) = x * y
+    evalAlg (x :*$ y) = foldl' (*) x y
 
     divCoalg x
         | x < 5     = LitF x
-        | even x    = MulF 2 x'
+        | even x    = 2 :*$ [x']
         | otherwise = AddF x' (x - x')
       where
         x' = x `div` 2

--- a/examples/Expr.hs
+++ b/examples/Expr.hs
@@ -4,6 +4,8 @@ module Main where
 import Data.Functor.Foldable
 import Data.Functor.Foldable.TH
 
+import Test.HUnit
+
 data Expr a
     = Lit a
     | Add (Expr a) (Expr a)
@@ -18,8 +20,8 @@ expr1 = Add (Lit 2) (Mul (Lit 3) (Lit 4))
 main :: IO ()
 main = do
     let expr2 = ana divCoalg 55 :: Expr Int
-    print $ cata evalAlg expr1
-    print $ cata evalAlg expr2
+    14 @=? cata evalAlg expr1
+    55 @=? cata evalAlg expr2
 
     -- assert expr1 evaluates to 14
     -- assert expr2 evaluates to 55, QuickCheck ?

--- a/examples/Expr.hs
+++ b/examples/Expr.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE TemplateHaskell, KindSignatures, DeriveFunctor, TypeFamilies #-}
+{-# LANGUAGE TemplateHaskell, KindSignatures, DeriveTraversable, TypeFamilies #-}
 module Main where
 
 import Data.Functor.Foldable

--- a/examples/Expr.hs
+++ b/examples/Expr.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE TemplateHaskell, KindSignatures, DeriveFunctor, TypeFamilies #-}
+module Main where
+
+import Data.Functor.Foldable
+import Data.Functor.Foldable.TH
+
+data Expr a
+    = Lit a
+    | Add (Expr a) (Expr a)
+    | Mul (Expr a) (Expr a)
+  deriving (Show)
+
+makeBaseFunctor ''Expr
+
+expr1 :: Expr Int
+expr1 = Add (Lit 2) (Mul (Lit 3) (Lit 4))
+
+main :: IO ()
+main = do
+    let expr2 = ana divCoalg 55 :: Expr Int
+    print $ cata evalAlg expr1
+    print $ cata evalAlg expr2
+
+    -- assert expr1 evaluates to 14
+    -- assert expr2 evaluates to 55, QuickCheck ?
+  where
+    evalAlg (LitF x)   = x
+    evalAlg (AddF x y) = x + y
+    evalAlg (MulF x y) = x * y
+
+    divCoalg x
+        | x < 5     = LitF x
+        | even x    = MulF 2 x'
+        | otherwise = AddF x' (x - x')
+      where
+        x' = x `div` 2

--- a/recursion-schemes.cabal
+++ b/recursion-schemes.cabal
@@ -59,6 +59,9 @@ library
     exposed-modules:
       Data.Functor.Foldable.TH
 
+    other-modules:
+      Paths_recursion_schemes
+
   ghc-options: -Wall
 
 test-suite Expr

--- a/recursion-schemes.cabal
+++ b/recursion-schemes.cabal
@@ -55,7 +55,7 @@ library
     Data.Functor.Foldable
 
   if flag(template-haskell)
-    build-depends: template-haskell >= 2.5.0.0 && <2.12
+    build-depends: template-haskell >= 2.5.0.0 && < 2.12, base-orphans >= 0.5.4 && <0.6
     exposed-modules:
       Data.Functor.Foldable.TH
 

--- a/recursion-schemes.cabal
+++ b/recursion-schemes.cabal
@@ -2,7 +2,7 @@ name:          recursion-schemes
 category:      Control, Recursion
 version:       5
 license:       BSD3
-cabal-version: >= 1.6
+cabal-version: >= 1.8
 license-file:  LICENSE
 author:        Edward A. Kmett
 maintainer:    Edward A. Kmett <ekmett@gmail.com>
@@ -21,6 +21,11 @@ extra-source-files: .travis.yml CHANGELOG.markdown .gitignore README.markdown
 source-repository head
   type: git
   location: git://github.com/ekmett/recursion-schemes.git
+
+flag template-haskell
+  description: About Template Haskell derivations
+  manual: True
+  default: True
 
 library
   extensions: CPP
@@ -49,4 +54,18 @@ library
     Data.Functor.Base
     Data.Functor.Foldable
 
+  if flag(template-haskell)
+    build-depends: template-haskell >= 2.5.0.0 && <2.12
+    exposed-modules:
+      Data.Functor.Foldable.TH
+
   ghc-options: -Wall
+
+test-suite Expr
+  type: exitcode-stdio-1.0
+  main-is: Expr.hs
+  hs-source-dirs: examples
+  ghc-options: -Wall -threaded
+  build-depends:
+    base,
+    recursion-schemes

--- a/recursion-schemes.cabal
+++ b/recursion-schemes.cabal
@@ -1,6 +1,6 @@
 name:          recursion-schemes
 category:      Control, Recursion
-version:       5
+version:       5.0.1
 license:       BSD3
 cabal-version: >= 1.8
 license-file:  LICENSE

--- a/recursion-schemes.cabal
+++ b/recursion-schemes.cabal
@@ -68,4 +68,5 @@ test-suite Expr
   ghc-options: -Wall -threaded
   build-depends:
     base,
+    HUnit <1.6,
     recursion-schemes


### PR DESCRIPTION
Based on the @pacak gist in #13 

- [x] improve test
- [x] Don't use `{-# LANGUAGE TemplateHaskell #-}`
- [x] support newtypes, records
- [x] infix type constructors / fields
- [x] proper `substType`
- [x] other GHCs
- [x] GADT example

---

This is WIP, but if Ryan could comment on this stage of PR that will be great. My Template Haskell -fu isn't well trained.

---

*EDIT* my goal is to support enough data types to work with simple `Expr` of toy-languages