### PR TITLE
Retidy dependencies

### DIFF
--- a/Data/Functor/Base.hs
+++ b/Data/Functor/Base.hs
@@ -1,6 +1,11 @@
 {-# LANGUAGE CPP #-}
 
-#define EXPLICIT_DICT_FUNCTOR_CLASSES (MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,5,0))
+-- See Data.Functor.Foldable for explanation
+#ifndef MIN_VERSION_transformers_compat
+#define MIN_VERSION_transformers_compat(x,y,z) 0
+#endif
+
+#define EXPLICIT_DICT_FUNCTOR_CLASSES (MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,5,0) || (MIN_VERSION_transformers_compat(0,5,0) && !MIN_VERSION_transformers(0,4,0)))
 
 #define HAS_GENERIC (__GLASGOW_HASKELL__ >= 702)
 #define HAS_GENERIC1 (__GLASGOW_HASKELL__ >= 706)

--- a/Data/Functor/Foldable.hs
+++ b/Data/Functor/Foldable.hs
@@ -4,7 +4,13 @@
 -- - base-4.9
 -- - transformers >= 0.5
 -- - transformes-compat >= 0.5 when transformers aren't 0.4
-#define EXPLICIT_DICT_FUNCTOR_CLASSES (MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,5,0))
+--
+-- We don't always depend on transformers-compat, so we need a shim for its version check.
+#ifndef MIN_VERSION_transformers_compat
+#define MIN_VERSION_transformers_compat(x,y,z) 0
+#endif
+
+#define EXPLICIT_DICT_FUNCTOR_CLASSES (MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,5,0) || (MIN_VERSION_transformers_compat(0,5,0) && !MIN_VERSION_transformers(0,4,0)))
 
 #define HAS_GENERIC (__GLASGOW_HASKELL__ >= 702)
 #define HAS_GENERIC1 (__GLASGOW_HASKELL__ >= 706)

--- a/Data/Functor/Foldable/TH.hs
+++ b/Data/Functor/Foldable/TH.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE Rank2Types #-}
+{-# LANGUAGE CPP, Rank2Types #-}
 module Data.Functor.Foldable.TH
   ( makeBaseFunctor
   , makeBaseFunctorWith

--- a/recursion-schemes.cabal
+++ b/recursion-schemes.cabal
@@ -31,8 +31,8 @@ flag template-haskell
   default: True
 
 library
-  extensions: CPP
   other-extensions:
+    CPP
     TypeFamilies
     Rank2Types
     FlexibleContexts
@@ -42,33 +42,43 @@ library
     UndecidableInstances
 
   build-depends:
-    base                 >= 4       && < 5,
+    base                 >= 4.5     && < 5,
     comonad              >= 4       && < 6,
     free                 >= 4       && < 6,
-    transformers         >= 0.3     && < 1
+    transformers         >= 0.3.0.0 && < 1
 
-  if impl(ghc < 8.2)
+  if !impl(ghc >= 8.2)
     build-depends: bifunctors >= 4 && < 6
 
-  if flag(template-haskell)
-    build-depends: th-abstraction >= 0.2.4 && < 1
-
-  if impl(ghc < 8.0)
-    build-depends: semigroups >= 0.8.3.1 && < 1
+  if !impl(ghc >= 8.0)
+    build-depends: semigroups >= 0.10 && < 1
 
   if impl(ghc < 7.5)
     build-depends: ghc-prim
 
-  if impl(ghc < 7.10)
-    build-depends: nats
-    build-depends: transformers-compat
+  -- Following two conditionals aren't inverses (there are other compilers than GHC)
+  --
+  -- We enforce the fact that with GHC-7.10
+  -- we have at least transformers-0.4.2.0 (the bundled one)
+  -- which has 'Data.Functor.Classes' module. (transformers-0.3 doesn't have)
+  if impl(ghc >= 7.10)
+    build-depends:
+      transformers         >= 0.4.2.0
+
+  if !impl(ghc >= 7.10)
+    build-depends:
+      nats,
+      transformers-compat  >= 0.3     && < 1
 
   exposed-modules:
     Data.Functor.Base
     Data.Functor.Foldable
 
   if flag(template-haskell)
-    build-depends: template-haskell >= 2.5.0.0 && < 2.14, base-orphans >= 0.5.4 && <0.8
+    build-depends:
+      template-haskell >= 2.5.0.0 && < 2.14,
+      base-orphans     >= 0.5.4   && < 0.8,
+      th-abstraction   >= 0.2.4   && < 1
     exposed-modules:
       Data.Functor.Foldable.TH
 


### PR DESCRIPTION
- CPP on transformers-compat version is important
- use !impl(ghc >= x.y) as it's semantically more correct
- we cannot have semigroups-0.8 (Numeric.Natural clash)
- with newer GHC we require tigher lower bound on `transformers`,
  then we don't need to depend on transformers-compat for all GHC
- combined template-haskell dependencies into own conditional block
- have explicit CPP in every module, move it to other-extensions
  (extensions field is not recommneded nowadays)

Follow up to #45. Don't merge yet, I want to verify the bounds properly (with different manual flag assignments), as we are on it (lower bounds seems correct for now). 