### PR TITLE
Add `Base Void = Identity` instance.

### DIFF
--- a/Data/Functor/Foldable.hs
+++ b/Data/Functor/Foldable.hs
@@ -117,6 +117,9 @@ import GHC.Generics (Generic)
 import GHC.Generics (Generic1)
 #endif
 #endif
+#if HAS_VOID
+import Data.Void
+#endif
 import Numeric.Natural
 import Data.Monoid (Monoid (..))
 import Prelude
@@ -317,6 +320,16 @@ instance Corecursive [a] where
     Cons x (Left xs) -> x : xs
     Cons x (Right b) -> x : apo f b
     Nil -> []
+
+#if HAS_VOID
+-- | @Fix Identity@ is equivalent to the following definition of 'Void':
+-- > newtype Void = Void Void
+type instance Base Void = Identity
+instance Recursive Void where
+  project = Identity
+instance Corecursive Void where
+  embed = runIdentity
+#endif
 
 type instance Base (NonEmpty a) = NonEmptyF a
 instance Recursive (NonEmpty a) where

--- a/include/recursion-schemes-common.h
+++ b/include/recursion-schemes-common.h
@@ -26,3 +26,5 @@
 #define HAS_GENERIC1 (__GLASGOW_HASKELL__ >= 706)
 
 #define HAS_POLY_TYPEABLE MIN_VERSION_base(4,7,0)
+
+#define HAS_VOID MIN_VERSION_base(4,8,0)


### PR DESCRIPTION
While chatting in #haskell on freenode, I realized that `Fix Identity` is a fancy way to say `Void`, since it is isomorphic to the following:

```haskell
newtype Void = Void Void

absurd :: Void -> a
absurd (Void v) = absurd v
```

I expected to find this instance in `recursion-schemes`, but didn't. This is a very simple addition, and I don't expect it to break anything.

I've added a `HAS_VOID` macro to `include/recursion-schemes-common.h` to only provide the Void instance when Void is provided by `base`. It would be possible to import it from `void` instead if we want to provide the instance for older compilers as well.

[![Build Status](https://travis-ci.org/Solonarv/recursion-schemes.svg?branch=base-void-instance)](https://travis-ci.org/Solonarv/recursion-schemes)