### PR TITLE
make a doctest testsuite

### DIFF
--- a/recursion-schemes.cabal
+++ b/recursion-schemes.cabal
@@ -104,3 +104,11 @@ test-suite Expr
     transformers     >= 0.2     && < 1
   if impl(ghc < 7.5)
     build-depends: ghc-prim
+
+test-suite doctests
+  default-language:   Haskell2010
+  type:               exitcode-stdio-1.0
+  ghc-options:        -threaded
+  main-is:            doctest-driver.hs
+  build-depends:      base >4 && <5, doctest
+  hs-source-dirs:     test, src

--- a/recursion-schemes.cabal
+++ b/recursion-schemes.cabal
@@ -105,10 +105,19 @@ test-suite Expr
   if impl(ghc < 7.5)
     build-depends: ghc-prim
 
-test-suite doctests
-  default-language:   Haskell2010
-  type:               exitcode-stdio-1.0
-  ghc-options:        -threaded
-  main-is:            doctest-driver.hs
-  build-depends:      base >4 && <5, doctest
-  hs-source-dirs:     test, src
+-- This is too fragile to be a test-suite, see
+-- https://github.com/ekmett/recursion-schemes/pull/68 and
+-- https://github.com/ekmett/recursion-schemes/pull/66#issuecomment-458139272
+-- for details.
+--
+-- Should nevertheless work with both
+--   cabal v2-run run-recursion-schemes-doctests
+-- and
+--   stack run run-recursion-schemes-doctests
+-- because they both happen to setup the proper environment.
+executable run-recursion-schemes-doctests
+  main-is: doctest-driver.hs
+  hs-source-dirs: test
+  build-depends:
+    base,
+    doctest

--- a/test/doctest-driver.hs
+++ b/test/doctest-driver.hs
@@ -1,0 +1,4 @@
+import Test.DocTest
+
+main :: IO ()
+main = doctest ["-isrc", "-Iinclude", "src/Data/Functor/Foldable.hs"]


### PR DESCRIPTION
As you can see, it doesn't [require `build-type: custom`](https://github.com/ekmett/recursion-schemes/pull/66#issuecomment-458124998) after all. For some reason `doctest-discover` decided to run zero tests, so I wrote my own runner.