### PR TITLE
Generics: support constructors with zero arguments

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,7 @@
+## 5.1.1.1
+* Fix the `Generic`-based instances to also support data constructors with zero
+  arguments (and datatypes with zero constructors).
+
 ## 5.1.1
 
 * Add `cotransverse`

--- a/examples/Expr.hs
+++ b/examples/Expr.hs
@@ -30,7 +30,8 @@ makeBaseFunctorWith (runIdentity $ return baseRules
     ) ''Expr2
 
 data Expr3 a
-    = Lit3 a
+    = Unit3
+    | Lit3 a
     | Add3 (Expr3 a) (Expr3 a)
     | OpA (Expr3 a) (Expr3 a) Int
     | OpB (Expr3 a) (Expr3 a) Char
@@ -41,7 +42,8 @@ data Expr3 a
   deriving (Show, Generic)
 
 data Expr3F a b
-    = Lit3F a
+    = Unit3F
+    | Lit3F a
     | Add3F b b
     | OpAF b b Int
     | OpBF b b Char

--- a/src/Data/Functor/Foldable.hs
+++ b/src/Data/Functor/Foldable.hs
@@ -118,7 +118,7 @@ import Data.Data hiding (gunfold)
 import qualified Data.Data as Data
 #endif
 #if HAS_GENERIC
-import GHC.Generics (Generic (..), M1 (..), K1 (..), (:+:) (..), (:*:) (..))
+import GHC.Generics (Generic (..), M1 (..), V1, U1, K1 (..), (:+:) (..), (:*:) (..))
 #endif
 #if HAS_GENERIC1
 import GHC.Generics (Generic1)
@@ -827,6 +827,12 @@ instance GCoerce f g => GCoerce (M1 i c f) (M1 i c' g) where
 -- R changes to/from P with GHC-7.4.2 at least.
 instance GCoerce (K1 i c) (K1 j c) where
     gcoerce = K1 . unK1
+
+instance GCoerce U1 U1 where
+    gcoerce = id
+
+instance GCoerce V1 V1 where
+    gcoerce = id
 
 instance (GCoerce f g, GCoerce f' g') => GCoerce (f :*: f') (g :*: g') where
     gcoerce (x :*: y) = gcoerce x :*: gcoerce y

--- a/src/Data/Functor/Foldable.hs
+++ b/src/Data/Functor/Foldable.hs
@@ -815,21 +815,6 @@ cotransverse :: (Recursive s, Corecursive t, Functor f)
 cotransverse n = ana (n . fmap project)
 
 -------------------------------------------------------------------------------
--- Not exposed anywhere
--------------------------------------------------------------------------------
-
--- | Read a list (using square brackets and commas), given a function
--- for reading elements.
-_readListWith :: ReadS a -> ReadS [a]
-_readListWith rp =
-    readParen False (\r -> [pr | ("[",s) <- lex r, pr <- readl s])
-  where
-    readl s = [([],t) | ("]",t) <- lex s] ++
-        [(x:xs,u) | (x,t) <- rp s, (xs,u) <- readl' t]
-    readl' s = [([],t) | ("]",t) <- lex s] ++
-        [(x:xs,v) | (",",t) <- lex s, (x,u) <- rp t, (xs,v) <- readl' u]
-
--------------------------------------------------------------------------------
 -- GCoerce
 -------------------------------------------------------------------------------
 


### PR DESCRIPTION
While writing an example for the new Generics-deriving feature in my Twitter release notes, I stumbled upon a bug: it doesn't work when constructors have zero arguments, e.g. for `data ListF a r = NilF | ConsF a r`. This is because the generic representation for those use `U1`, not `K1`.