### PR TITLE
Proper version bump to 5.1.2

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,6 +1,10 @@
-## 5.1.1.1
-* Fix the `Generic`-based instances to also support data constructors with zero
+## 5.1.2
+* Make the `Generic`-based instances to also support data constructors with zero
   arguments (and datatypes with zero constructors).
+
+## 5.1.1.1
+
+* Invalid release
 
 ## 5.1.1
 

--- a/recursion-schemes.cabal
+++ b/recursion-schemes.cabal
@@ -1,6 +1,6 @@
 name:          recursion-schemes
 category:      Control, Recursion
-version:       5.1.1
+version:       5.1.2
 license:       BSD3
 cabal-version: >= 1.8
 license-file:  LICENSE


### PR DESCRIPTION
PVP clearly says:

> Otherwise, e.g. if change consist only of corrected documentation,
non-visible change to allow different dependency range etc. A.B.C MAY
remain the same (other version components may change).

5.1.1 version entered Stackage nightly, so I'd rather blacklisted it
on Hackage, but I couldn't (to not cause surprises).
Now I made a revision adding unsatisfiable `base <0` boundsto 5.1.1.1 as
that release violated PVP contract.