### PR TITLE
Add Haddocks & doctests (WIP)

### DIFF
--- a/Setup.lhs
+++ b/Setup.lhs
@@ -1,7 +1,44 @@
-#!/usr/bin/runhaskell
-> module Main (main) where
+\begin{code}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Main (main) where
 
-> import Distribution.Simple
+#ifndef MIN_VERSION_cabal_doctest
+#define MIN_VERSION_cabal_doctest(x,y,z) 0
+#endif
 
-> main :: IO ()
-> main = defaultMain
+-- haddock stuff
+import Distribution.Package ( Package (..), packageName )
+import Distribution.Simple ( defaultMainWithHooks, UserHooks(..), simpleUserHooks )
+import Distribution.Simple.Setup (Flag (..), HaddockFlags, haddockDistPref)
+import Distribution.Simple.Utils (copyFiles)
+import Distribution.Verbosity (normal)
+import Distribution.Text ( display )
+import System.FilePath ( (</>) )
+
+#if MIN_VERSION_cabal_doctest(1,0,0)
+
+import Distribution.Extra.Doctest ( doctestsUserHooks )
+
+#else
+
+#ifdef MIN_VERSION_Cabal
+-- If the macro is defined, we have new cabal-install,
+-- but for some reason we don't have cabal-doctest in package-db
+--
+-- Probably we are running cabal sdist, when otherwise using new-build
+-- workflow
+import Warning ()
+#endif
+
+doctestsUserHooks :: String -> UserHooks
+doctestsUserHooks _ = simpleUserHooks
+
+#endif
+
+main :: IO ()
+main = defaultMainWithHooks duh
+  where
+    duh = doctestsUserHooks "doctests"
+
+\end{code}

--- a/doctests.hs
+++ b/doctests.hs
@@ -1,0 +1,12 @@
+module Main where
+
+import Build_doctests (flags, pkgs, module_sources)
+import Data.Foldable (traverse_)
+import Test.DocTest
+
+main :: IO ()
+main = do
+    traverse_ putStrLn args
+    doctest args
+  where
+    args = flags ++ pkgs ++ module_sources

--- a/recursion-schemes.cabal
+++ b/recursion-schemes.cabal
@@ -17,8 +17,14 @@ description:   Many recursive functions share the same structure, e.g. pattern-m
 
 tested-with:   GHC==7.4.2, GHC==7.6.3, GHC==7.8.4, GHC==7.10.3, GHC==8.0.2, GHC==8.2.2, GHC==8.4.4, GHC==8.6.3
 
-build-type:    Simple
+build-type:    Custom
 extra-source-files: .travis.yml CHANGELOG.markdown .gitignore README.markdown include/recursion-schemes-common.h
+custom-setup
+  setup-depends:
+    Cabal >= 1.10 && <2.5,
+    base  >= 4.5 && <5,
+    cabal-doctest >= 1 && <1.1,
+    filepath
 
 source-repository head
   type: git
@@ -103,3 +109,9 @@ test-suite Expr
     transformers     >= 0.2     && < 1
   if impl(ghc < 7.5)
     build-depends: ghc-prim
+
+test-suite doctests
+  type:          exitcode-stdio-1.0
+  ghc-options:   -threaded
+  main-is:       doctests.hs
+  build-depends: base, doctest >= 0.8, comonad, free

--- a/src/Data/Functor/Foldable.hs
+++ b/src/Data/Functor/Foldable.hs
@@ -879,6 +879,15 @@ distGApoT g k = fmap ExceptT . k . fmap (distGApo g) . runExceptT
 -- iteration. Like a 'cata'@morphism@, a histomorphism folds some structure, but
 -- unlike a catamorphism (which only has access to the immediate recursive call)
 -- a histomorphism has access to all recursive calls.
+--
+-- An example of a histomorphism is to generate the nth term of the Fibonacci
+-- sequence. Recall that generating a Fibonacci number requires the precedeeing
+-- term, but also the term that preceeds that:
+--
+-- > fib :: Natural -> Natural
+-- > fib n = histo $ \case Nothing -> 0
+-- >                       Just (_ :< Nothing) -> 1
+-- >                       Just (n :< Just (m :< _)) -> n + m
 histo :: Recursive t => (Base t (Cofree (Base t) a) -> a) -> t -> a
 histo = gcata distHisto
 


### PR DESCRIPTION
This pull request aims to add Haddocks to all exported symbols. I've made a good start, but would like feedback before continuing.

## Personal To Do List

- [ ] Drop `build-type: Custom`
- [ ] Move `cata`, `ana`, `hylo` documentation/examples to `fold`, `unfold`, `refold`.
- [ ] Drop `prepro` example, link to a blog post.
- [ ] Replace references to "pattern functor" with "base functor".