### PR TITLE
recursion-schemes.cabal: fix mis-declared license attribute

### DIFF
--- a/recursion-schemes.cabal
+++ b/recursion-schemes.cabal
@@ -1,7 +1,7 @@
 name:          recursion-schemes
 category:      Control, Recursion
 version:       5.1.2
-license:       BSD3
+license:       BSD2
 cabal-version: >= 1.8
 license-file:  LICENSE
 author:        Edward A. Kmett


### PR DESCRIPTION
The LICENSE file contains a BSD2 license, not BSD3.