### PR TITLE
Adapt to th-abstraction-0.3.0.0

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,6 @@
+## next [????.??.??]
+* Support `th-abstraction-0.3.0.0` or later.
+
 ## 5.1.2
 * Make the `Generic`-based instances to also support data constructors with zero
   arguments (and datatypes with zero constructors).

--- a/recursion-schemes.cabal
+++ b/recursion-schemes.cabal
@@ -81,7 +81,7 @@ library
     build-depends:
       template-haskell >= 2.5.0.0 && < 2.15,
       base-orphans     >= 0.5.4   && < 0.9,
-      th-abstraction   >= 0.2.4   && < 0.3
+      th-abstraction   >= 0.2.4   && < 0.4
     exposed-modules:
       Data.Functor.Foldable.TH
 


### PR DESCRIPTION
This adapts to a breaking change in the type of `datatypeVars` that was introduced in `th-abstraction-0.3.0.0`.