### PR TITLE
Issue 94/make doctest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 all : build
 
 build :
-	cabal new-build --enable-tests
+	cabal v2-build --enable-tests
 
 doctest :
 	doctest -DCURRENT_PACKAGE_KEY='"recursion-schemes"' -this-unit-id recursion-schemes -Iinclude src
 
 ghcid :
-	ghcid -c 'cabal new-repl'
+	ghcid -c 'cabal v2-repl'

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: all build doctest ghcid
+
 all : build
 
 build :

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,14 @@
-.PHONY: all build doctest ghcid
+.PHONY: all build test examples doctest ghcid
 
 all : build
 
 build :
 	cabal v2-build --enable-tests
+
+test : examples doctest
+
+examples :
+	cabal v2-test
 
 doctest :
 	cabal v2-exec -- doctest -DCURRENT_PACKAGE_KEY='"recursion-schemes"' -this-unit-id recursion-schemes -Iinclude src

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ build :
 	cabal v2-build --enable-tests
 
 doctest :
-	doctest -DCURRENT_PACKAGE_KEY='"recursion-schemes"' -this-unit-id recursion-schemes -Iinclude src
+	cabal v2-exec -- doctest -DCURRENT_PACKAGE_KEY='"recursion-schemes"' -this-unit-id recursion-schemes -Iinclude src
 
 ghcid :
 	ghcid -c 'cabal v2-repl'


### PR DESCRIPTION
Fixes #94

* Use `v2-*` cabal commands instead of `new-*`
* Use `cabal exec` to make sure `doctest` can see the built package
* Add `make examples` target (we have more tests than just doctests)
* Add `make test` target which runs both `make examples` and `make doctests`