### PR TITLE
Add mana, mapo and mfutu

### DIFF
--- a/src/Data/Functor/Foldable.hs
+++ b/src/Data/Functor/Foldable.hs
@@ -73,6 +73,8 @@ module Data.Functor.Foldable
   , refold, grefold
   -- * Mendler-style
   , mcata
+  , mpara
+  , mzygo
   , mhisto
   , mana
   , mapo
@@ -602,6 +604,14 @@ gchrono w m = ghylo (distGHisto w) (distGFutu m)
 -- | Mendler-style iteration
 mcata :: (forall y. (y -> c) -> f y -> c) -> Fix f -> c
 mcata psi = c where c = psi c . unFix
+
+-- | Mendler-style version of 'para'
+mpara :: (forall y. (y -> c) -> (y -> Fix f) -> f y -> c) -> Fix f -> c
+mpara psi = c where c = psi c id . unFix
+
+-- | Mendler-style version of 'zygo'
+mzygo :: (forall y. (y -> b) -> f y -> b) -> (forall y. (y -> c) -> (y -> b) -> f y -> c) -> Fix f -> c
+mzygo phi psi = c where c = psi c (mcata phi) . unFix
 
 -- | Mendler-style course-of-value iteration
 mhisto :: (forall y. (y -> c) -> (y -> f y) -> f y -> c) -> Fix f -> c

--- a/src/Data/Functor/Foldable.hs
+++ b/src/Data/Functor/Foldable.hs
@@ -605,11 +605,15 @@ gchrono w m = ghylo (distGHisto w) (distGFutu m)
 mcata :: (forall y. (y -> c) -> f y -> c) -> Fix f -> c
 mcata psi = c where c = psi c . unFix
 
--- | Mendler-style version of 'para'
+-- | Mendler-style recursion
+--
+-- @since 5.2.1
 mpara :: (forall y. (y -> c) -> (y -> Fix f) -> f y -> c) -> Fix f -> c
 mpara psi = c where c = psi c id . unFix
 
--- | Mendler-style version of 'zygo'
+-- | Mendler-style semi-mutual recursion
+--
+-- @since 5.2.1
 mzygo :: (forall y. (y -> b) -> f y -> b) -> (forall y. (y -> c) -> (y -> b) -> f y -> c) -> Fix f -> c
 mzygo phi psi = c where c = psi c (mcata phi) . unFix
 

--- a/src/Data/Functor/Foldable.hs
+++ b/src/Data/Functor/Foldable.hs
@@ -74,6 +74,9 @@ module Data.Functor.Foldable
   -- * Mendler-style
   , mcata
   , mhisto
+  , mana
+  , mapo
+  , mfutu
   -- * Elgot (co)algebras
   , elgot
   , coelgot
@@ -598,11 +601,29 @@ gchrono w m = ghylo (distGHisto w) (distGFutu m)
 
 -- | Mendler-style iteration
 mcata :: (forall y. (y -> c) -> f y -> c) -> Fix f -> c
-mcata psi = psi (mcata psi) . unFix
+mcata psi = c where c = psi c . unFix
 
 -- | Mendler-style course-of-value iteration
 mhisto :: (forall y. (y -> c) -> (y -> f y) -> f y -> c) -> Fix f -> c
-mhisto psi = psi (mhisto psi) unFix . unFix
+mhisto psi = c where c = psi c unFix . unFix
+
+-- | Mendler-style coiteration
+--
+-- @since 5.2.1
+mana :: (forall y. (x -> y) -> x -> f y) -> x -> Fix f
+mana phi = c where c = Fix . phi c
+
+-- | Mendler-style corecursion
+--
+-- @since 5.2.1
+mapo :: (forall y. (Fix f -> y) -> (x -> y) -> x -> f y) -> x -> Fix f
+mapo phi = c where c = Fix . phi id c
+
+-- | Mendler-style course-of-values coiteration
+--
+-- @since 5.2.1
+mfutu :: (forall y. (f y -> y) -> (x -> y) -> x -> f y) -> x -> Fix f
+mfutu phi = c where c = Fix . phi Fix c
 
 -- | Elgot algebras
 elgot :: Functor f => (f a -> a) -> (b -> Either a (f b)) -> b -> a


### PR DESCRIPTION
It would be great to generalize mendler combinators to `t` and `Base t`, but that would be breaking change. In other words:

```diff
 -- | Mendler-style iteration
-mcata :: (forall y. (y -> c) -> f y -> c) -> Fix f -> c
-mcata psi = c where c = psi c . unFix
+mcata :: Recursive t => (forall y. (y -> c) -> Base t y -> c) -> t -> c
+mcata psi = c where c = psi c . project
```