### PR TITLE
Allow building with template-haskell-2.17.0.0 (GHC 9.0)

### DIFF
--- a/recursion-schemes.cabal
+++ b/recursion-schemes.cabal
@@ -92,6 +92,8 @@ library
       Paths_recursion_schemes
 
   ghc-options: -Wall
+  if impl(ghc >= 8.6)
+    ghc-options: -Wno-star-is-type
   default-language: Haskell2010
 
 test-suite Expr

--- a/recursion-schemes.cabal
+++ b/recursion-schemes.cabal
@@ -82,9 +82,9 @@ library
 
   if flag(template-haskell)
     build-depends:
-      template-haskell >= 2.5.0.0 && < 2.17,
+      template-haskell >= 2.5.0.0 && < 2.18,
       base-orphans     >= 0.5.4   && < 0.9,
-      th-abstraction   >= 0.3     && < 0.4
+      th-abstraction   >= 0.4     && < 0.5
     exposed-modules:
       Data.Functor.Foldable.TH
 


### PR DESCRIPTION
This involves using `th-abstraction-0.4` or later.