### PR TITLE
a Tree example for 'fold'

### DIFF
--- a/Setup.lhs
+++ b/Setup.lhs
@@ -1,7 +1,0 @@
-#!/usr/bin/runhaskell
-> module Main (main) where
-
-> import Distribution.Simple
-
-> main :: IO ()
-> main = defaultMain

--- a/src/Data/Functor/Foldable.hs
+++ b/src/Data/Functor/Foldable.hs
@@ -215,7 +215,7 @@ class Functor (Base t) => Recursive t where
   --
   -- The names might seem intimidating at first, but using the standard nomenclature has benefits. If you program with others, it can be useful to have a shared vocabulary to refer to those recursion patterns. For example, you can discuss which type of recursion is the most appropriate for the problem at hand. Names can also help to structure your thoughts while writing recursive functions.
   --
-  -- The rest of this module lists a few of the other recursion-schemes which are common enough to have a name. In this section, we restrict our attention to those which fold a recursive structure down to a value. Our examples will thus all be functions of type @Tree Int -> String@.
+  -- The rest of this module lists a few of the other recursion-schemes which are common enough to have a name. In this section, we restrict our attention to those which fold a recursive structure down to a value. In the examples all functions will be of type @Tree Int -> String@.
   cata :: (Base t a -> a) -> t -> a
   cata f = c where c = f . fmap c . project
 

--- a/src/Data/Functor/Foldable.hs
+++ b/src/Data/Functor/Foldable.hs
@@ -308,6 +308,16 @@ hylo f g = h where h = f . fmap h . g
 
 -- | Folds a recursive type down to a value, one layer at a time.
 --
+-- >>> :{
+-- let mySum :: [Int] -> Int
+--     mySum = fold $ \case
+--       Nil -> 0
+--       Cons x sumXs -> x + sumXs
+-- :}
+--
+-- >>> mySum [10,11,12]
+-- 33
+--
 -- In our running example, one layer consists of an 'Int' and a list of recursive positions. In @Tree Int@, those recursive positions contain sub-trees of type @Tree Int@. Since we are working one layer at a time, the @Base t a -> a@ function is not given a @Tree Int@, but a @TreeF Int String@. That is, each recursive position contains the 'String' resulting from recursively folding the corresponding sub-tree.
 --
 -- >>> :{


### PR DESCRIPTION
`fold` already had some good documentation, with an example implementation of `sum`. This new version of the documentation uses a function on a Tree instead of a list, because we think that will allow us to give visual examples for all the recursion-schemes.